### PR TITLE
Fix compiler warnings across project

### DIFF
--- a/fetch-debug/src/main/scala/document.scala
+++ b/fetch-debug/src/main/scala/document.scala
@@ -42,7 +42,7 @@ abstract class Document {
    * Format this document on `writer` and try to set line
    * breaks so that the result fits in `width` columns.
    */
-  def format(width: Int, writer: Writer) {
+  def format(width: Int, writer: Writer): Unit = {
     type FmtState = (Int, Boolean, Document)
 
     def fits(w: Int, state: List[FmtState]): Boolean =
@@ -67,7 +67,7 @@ abstract class Document {
           fits(w, (i, false, d) :: z)
       }
 
-    def spaces(n: Int) {
+    def spaces(n: Int): Unit = {
       var rem = n
       while (rem >= 16) { writer write "                "; rem -= 16 }
       if (rem >= 8) { writer write "        "; rem -= 8 }

--- a/fetch/src/main/scala/fetch.scala
+++ b/fetch/src/main/scala/fetch.scala
@@ -166,7 +166,8 @@ object `package` {
           val newRequest = Batch(combined, ds)
           val newResult = CombinationSuspend((r: FetchStatus) =>
             r match {
-              case FetchDone(m: Map[Any, Any]) =>
+              case FetchDone(preM) =>
+                val m       = preM.asInstanceOf[Map[Any, Any]]
                 val xResult = m.get(aId).map(FetchDone(_)).getOrElse(FetchMissing())
                 val yResult = m.get(anotherId).map(FetchDone(_)).getOrElse(FetchMissing())
                 CombinationBarrier(() => x.result, xResult)
@@ -184,7 +185,8 @@ object `package` {
         val newRequest = Batch(combined, ds)
         val newResult = CombinationSuspend((r: FetchStatus) =>
           r match {
-            case FetchDone(m: Map[Any, Any]) =>
+            case FetchDone(preM) =>
+              val m         = preM.asInstanceOf[Map[Any, Any]]
               val oneResult = m.get(oneId).map(FetchDone(_)).getOrElse(FetchMissing())
               CombinationBarrier(() => x.result, oneResult)
                 .flatMap(() => y.result)
@@ -201,7 +203,8 @@ object `package` {
         val newRequest = Batch(combined, ds)
         val newResult = CombinationSuspend((r: FetchStatus) =>
           r match {
-            case FetchDone(m: Map[Any, Any]) =>
+            case FetchDone(preM) =>
+              val m         = preM.asInstanceOf[Map[Any, Any]]
               val oneResult = m.get(oneId).map(FetchDone(_)).getOrElse(FetchMissing())
               CombinationBarrier(() => y.result, oneResult)
                 .flatMap(() => x.result)
@@ -258,8 +261,8 @@ object `package` {
 
   // Fetch Monad
 
-  implicit def fetchM[F[_]: Monad]: Monad[Fetch[F, ?]] =
-    new Monad[Fetch[F, ?]] with StackSafeMonad[Fetch[F, ?]] {
+  implicit def fetchM[F[_]: Monad]: Monad[Fetch[F, *]] =
+    new Monad[Fetch[F, *]] with StackSafeMonad[Fetch[F, *]] {
       def pure[A](a: A): Fetch[F, A] =
         Unfetch(
           Monad[F].pure(Done(a))


### PR DESCRIPTION
Some code used features of Scala or http4s that either were deprecated, or confused the compiler while being technically usable. This tweaks the code that's there just enough to get it all working without warnings.

* No more procedure syntax
* Pattern matching casts are now done explicitly
* http4s client `.fetch` syntax is deprecated, replaced w/ `.run.use`
* Replace `?` with `*` for kind projector usage