### PR TITLE
Fix problem with fibers being cancelled due to timeout and causing fetch deadlock

### DIFF
--- a/fetch/src/main/scala/datasource.scala
+++ b/fetch/src/main/scala/datasource.scala
@@ -114,7 +114,7 @@ object DataSource {
   ): Resource[F, DataSource[F, I, A]] = {
     type Callback = Either[Throwable, Option[A]] => Unit
     for {
-      queue <- Resource.eval(Queue.unbounded[F, (I, Callback)])
+      queue      <- Resource.eval(Queue.unbounded[F, (I, Callback)])
       supervisor <- Supervisor[F]
       workerFiber = upToWithin(
         queue,
@@ -124,7 +124,7 @@ object DataSource {
         if (x.isEmpty) {
           supervisor.supervise(F.unit)
         } else {
-          val asMap = x.groupBy(_._1).mapValues(callbacks => callbacks.map(_._2))
+          val asMap        = x.groupBy(_._1).mapValues(callbacks => callbacks.map(_._2))
           val batchResults = dataSource.batch(NonEmptyList.fromListUnsafe(asMap.keys.toList))
           val resultsHaveBeenSent = batchResults.map { results =>
             asMap.foreach { case (identity, callbacks) =>


### PR DESCRIPTION
Hi again, it seems that the process for batching across requests suffers from a deadlock issue.

In particular it can be triggered if the timeout occurs between the time the queue has been popped and the buffer is updated.

To fix this I just wrapped it in an `F.uncancelable` to fix the deadlock, safely updating the reference before cancellation is finished