### PR TITLE
Replace implicit traverse behavior with explicit batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ A library for Simple & Efficient data access in Scala and Scala.js
 
 Add the following dependency to your project's build file.
 
-For Scala 2.11.x and 2.12.x:
+For Scala 2.11.x through 3.x:
 
 ```scala
-"com.47deg" %% "fetch" % "2.1.1"
+"com.47deg" %% "fetch" % "3.0.0"
 ```
 
 Or, if using Scala.js (0.6.x):

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ For Scala 2.12.x through 3.x:
 "com.47deg" %% "fetch" % "3.0.0"
 ```
 
-Or, if using Scala.js (0.6.x):
+Or, if using Scala.js (1.0.x):
 
 ```scala
-"com.47deg" %%% "fetch" % "2.1.1"
+"com.47deg" %%% "fetch" % "3.0.0"
 ```
 
 
@@ -105,19 +105,14 @@ def fetchString[F[_] : Async](n: Int): Fetch[F, String] =
 
 ## Creating a runtime
 
-Since `Fetch` relies on `Concurrent` from the `cats-effect` library, we'll need a runtime for executing our effects. We'll be using `IO` from `cats-effect` to run fetches, but you can use any type that has a `Concurrent` instance.
+Since we'll use `IO` from the `cats-effect` library to execute our fetches, we'll need an `IORuntime` for executing our `IO` instances.
 
-For executing `IO`, we need a `ContextShift[IO]` used for running `IO` instances and a `Timer[IO]` that is used for scheduling. Let's go ahead and create them. We'll use a `java.util.concurrent.ScheduledThreadPoolExecutor` with a couple of threads to run our fetches.
-
-```scala
-import java.util.concurrent._
-import scala.concurrent.ExecutionContext
-
-val executor = new ScheduledThreadPoolExecutor(4)
-val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
-
-import cats.effect.unsafe.implicits.global
+```scala mdoc:silent
+import cats.effect.unsafe.implicits.global //Gives us an IORuntime in places it is normally not provided
 ```
+
+Normally, in your applications, this is provided by `IOApp`, and you should not need to import this except in limited scenarios such as test environments that do not have Cats Effect integration.
+For more information, and particularly on why you would usually not want to make one of these yourself, [see this post by Daniel Spiewak](https://github.com/typelevel/cats-effect/discussions/1562#discussioncomment-254838)
 
 ## Creating and running a fetch
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A library for Simple & Efficient data access in Scala and Scala.js
 
 Add the following dependency to your project's build file.
 
-For Scala 2.11.x through 3.x:
+For Scala 2.12.x through 3.x:
 
 ```scala
 "com.47deg" %% "fetch" % "3.0.0"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For Scala 2.12.x through 3.x:
 "com.47deg" %% "fetch" % "3.0.0"
 ```
 
-Or, if using Scala.js (1.0.x):
+Or, if using Scala.js (1.8.x):
 
 ```scala
 "com.47deg" %%% "fetch" % "3.0.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ For Scala 2.12.x through 3.x:
 "com.47deg" %% "fetch" % "@VERSION@"
 ```
 
-Or, if using Scala.js (1.x):
+Or, if using Scala.js (1.8.x):
 
 ```scala
 "com.47deg" %%% "fetch" % "@VERSION@"

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,13 +13,13 @@ A library for Simple & Efficient data access in Scala and Scala.js
 
 Add the following dependency to your project's build file.
 
-For Scala 2.11.x and 2.12.x:
+For Scala 2.12.x through 3.x:
 
 ```scala
 "com.47deg" %% "fetch" % "@VERSION@"
 ```
 
-Or, if using Scala.js (0.6.x):
+Or, if using Scala.js (1.x):
 
 ```scala
 "com.47deg" %%% "fetch" % "@VERSION@"
@@ -106,19 +106,14 @@ def fetchString[F[_] : Async](n: Int): Fetch[F, String] =
 
 ## Creating a runtime
 
-Since `Fetch` relies on `Concurrent` from the `cats-effect` library, we'll need a runtime for executing our effects. We'll be using `IO` from `cats-effect` to run fetches, but you can use any type that has a `Concurrent` instance.
-
-For executing `IO`, we need a `ContextShift[IO]` used for running `IO` instances and a `Timer[IO]` that is used for scheduling. Let's go ahead and create them. We'll use a `java.util.concurrent.ScheduledThreadPoolExecutor` with a couple of threads to run our fetches.
+Since we'll use `IO` from the `cats-effect` library to execute our fetches, we'll need an `IORuntime` for executing our `IO` instances.
 
 ```scala mdoc:silent
-import java.util.concurrent._
-import scala.concurrent.ExecutionContext
-
-val executor = new ScheduledThreadPoolExecutor(4)
-val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
-
-import cats.effect.unsafe.implicits.global
+import cats.effect.unsafe.implicits.global //Gives us an IORuntime in places it is normally not provided
 ```
+
+Normally, in your applications, this is provided by `IOApp`, and you should not need to import this except in limited scenarios such as test environments that do not have Cats Effect integration.
+For more information, and particularly on why you would usually not want to make one of these yourself, [see this post by Daniel Spiewak](https://github.com/typelevel/cats-effect/discussions/1562#discussioncomment-254838)
 
 ## Creating and running a fetch
 
@@ -282,10 +277,6 @@ runFetchFourTimesSharedCache.unsafeRunTimed(5.seconds)
 
 As you can see above, the cache will now work between calls and can be used to deduplicate requests over a period of time.
 Note that this does not support any kind of automatic cache invalidation, so you will need to keep track of which values you want to re-fetch if you plan on sharing the cache.
-
-```scala mdoc:invisible
-executor.shutdownNow()
-```
 ---
 
 For more in-depth information, take a look at our [documentation](https://47degrees.github.io/fetch/docs.html).

--- a/fetch-examples/src/test/scala/DoobieExample.scala
+++ b/fetch-examples/src/test/scala/DoobieExample.scala
@@ -150,7 +150,7 @@ class DoobieExample extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   "We can fetch multiple authors from the DB in parallel" in {
     def fetch[F[_]: Async]: Fetch[F, List[Author]] =
-      List(1, 2).traverse(Authors.fetchAuthor[F])
+      Fetch.batchAll(List(1, 2).map(Authors.fetchAuthor[F]): _*)
 
     val io: IO[(Log, List[Author])] = Fetch.runLog[IO](fetch)
 

--- a/fetch-examples/src/test/scala/DoobieExample.scala
+++ b/fetch-examples/src/test/scala/DoobieExample.scala
@@ -31,6 +31,7 @@ import scala.concurrent.ExecutionContext
 import java.util.concurrent.Executors
 
 import fetch._
+import fetch.syntax._
 
 object DatabaseExample {
   case class AuthorId(id: Int)
@@ -150,7 +151,7 @@ class DoobieExample extends AnyWordSpec with Matchers with BeforeAndAfterAll {
 
   "We can fetch multiple authors from the DB in parallel" in {
     def fetch[F[_]: Async]: Fetch[F, List[Author]] =
-      Fetch.batchAll(List(1, 2).map(Authors.fetchAuthor[F]): _*)
+      List(1, 2).map(Authors.fetchAuthor[F]).batchAll
 
     val io: IO[(Log, List[Author])] = Fetch.runLog[IO](fetch)
 

--- a/fetch-examples/src/test/scala/GithubExample.scala
+++ b/fetch-examples/src/test/scala/GithubExample.scala
@@ -17,6 +17,7 @@
 import cats.effect._
 import cats.syntax.all._
 import fetch.{Data, DataSource, Fetch}
+import fetch.syntax._
 import io.circe._
 import io.circe.generic.semiauto._
 import org.http4s._
@@ -204,7 +205,7 @@ class GithubExample extends AnyWordSpec with Matchers {
   def fetchOrg[F[_]: Async](org: String) =
     for {
       repos    <- orgRepos(org)
-      projects <- repos.traverse(fetchProject[F])
+      projects <- repos.batchAllWith(fetchProject[F])
     } yield projects
 
   def fetchOrgStars[F[_]: Async](org: String): Fetch[F, Int] =

--- a/fetch-examples/src/test/scala/GraphQLExample.scala
+++ b/fetch-examples/src/test/scala/GraphQLExample.scala
@@ -23,6 +23,7 @@ import atto._, Atto._
 import cats.syntax.all._
 import cats.data.NonEmptyList
 import cats.effect._
+import fetch.syntax._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -206,7 +207,7 @@ class GraphQLExample extends AnyWordSpec with Matchers {
                 Project(name >> Some(repo.name), ls, cs)
               }
             }
-            Fetch.batchAll(fetches: _*)
+            fetches.batchAll
           }
         } yield projects
 
@@ -220,7 +221,7 @@ class GraphQLExample extends AnyWordSpec with Matchers {
             val fetches = repos.map { r =>
               Languages.fetch(r).map(ls => Project(name >> Some(r.name), ls, List()))
             }
-            Fetch.batchAll(fetches: _*)
+            fetches.batchAll
           }
         } yield projects
 
@@ -231,7 +232,7 @@ class GraphQLExample extends AnyWordSpec with Matchers {
             val fetches = repos.map { r =>
               Collaborators.fetch(r).map(cs => Project(name >> Some(r.name), List(), cs))
             }
-            Fetch.batchAll(fetches: _*)
+            fetches.batchAll
           }
         } yield projects
     }

--- a/fetch-examples/src/test/scala/Http4sExample.scala
+++ b/fetch-examples/src/test/scala/Http4sExample.scala
@@ -34,6 +34,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import java.util.concurrent._
 
 import fetch._
+import fetch.syntax._
 
 object HttpExample {
   case class UserId(id: Int)
@@ -114,7 +115,7 @@ object HttpExample {
     fetchUserById(UserId(id))
 
   def fetchManyUsers[F[_]: Async](ids: List[Int]): Fetch[F, List[User]] =
-    Fetch.batchAll(ids.map(i => fetchUserById(UserId(i))): _*)
+    ids.map(i => fetchUserById(UserId(i))).batchAll
 
   def fetchPosts[F[_]: Async](user: User): Fetch[F, (User, List[Post])] =
     fetchPostsForUser(user.id).map(posts => (user, posts))
@@ -149,7 +150,7 @@ class Http4sExample extends AnyWordSpec with Matchers {
     def fetch[F[_]: Async]: Fetch[F, List[(User, List[Post])]] =
       for {
         users          <- fetchManyUsers(List(1, 2))
-        usersWithPosts <- Fetch.batchAll(users.map(fetchPosts[F]): _*)
+        usersWithPosts <- users.map(fetchPosts[F]).batchAll
       } yield usersWithPosts
 
     val io = Fetch.runLog[IO](fetch)

--- a/fetch/src/main/scala/fetch.scala
+++ b/fetch/src/main/scala/fetch.scala
@@ -369,13 +369,12 @@ object `package` {
      * `traverse` on lists of `Fetch` values.
      */
     def batchAll[F[_]: Monad, A](fetches: Fetch[F, A]*): Fetch[F, List[A]] = {
-      fetches.toNeSeq
+      fetches.toList.toNel
         .map { nes =>
           nes
             .map(_.map(Chain.one(_)))
             .reduceLeft { (fa, fb) =>
-              val mon = Monad[Fetch[F, *]]
-              mon.map2(fa, fb)((a, b) => a ++ b)
+              fetchM[F].map2(fa, fb)((a, b) => a ++ b)
             }
             .map(_.toList)
         }

--- a/fetch/src/main/scala/fetch.scala
+++ b/fetch/src/main/scala/fetch.scala
@@ -303,7 +303,7 @@ object `package` {
           }
         } yield result)
 
-      override def product[A, B](fa: Fetch[F, A], fb: Fetch[F, B]): Fetch[F, (A, B)] =
+      override def product[A, B](fa: Fetch[F, A], fb: Fetch[F, B]): Fetch[F, (A, B)] = {
         Unfetch[F, (A, B)](for {
           fab <- (fa.run, fb.run).tupled
           result = fab match {
@@ -321,6 +321,7 @@ object `package` {
               Throw[F, (A, B)](e)
           }
         } yield result)
+      }
 
       override def productR[A, B](fa: Fetch[F, A])(fb: Fetch[F, B]): Fetch[F, B] =
         Unfetch[F, B](for {
@@ -359,6 +360,27 @@ object `package` {
      */
     def pure[F[_]: Applicative, A](a: A): Fetch[F, A] =
       Unfetch(Applicative[F].pure(Done(a)))
+
+    /**
+     * Given a number of fetches, returns all of the results in a `List`. In the event that multiple
+     * fetches are made to the same data source, this will attempt to batch them together.
+     *
+     * This should be used in code that previously relied on the auto-batching behavior of calling
+     * `traverse` on lists of `Fetch` values.
+     */
+    def batchAll[F[_]: Monad, A](fetches: Fetch[F, A]*): Fetch[F, List[A]] = {
+      fetches.toNeSeq
+        .map { nes =>
+          nes
+            .map(_.map(Chain.one(_)))
+            .reduceLeft { (fa, fb) =>
+              val mon = Monad[Fetch[F, *]]
+              mon.map2(fa, fb)((a, b) => a ++ b)
+            }
+            .map(_.toList)
+        }
+        .getOrElse(Fetch.pure[F, List[A]](List.empty))
+    }
 
     def exception[F[_]: Applicative, A](e: Log => FetchException): Fetch[F, A] =
       Unfetch(Applicative[F].pure(Throw[F, A](e)))

--- a/fetch/src/main/scala/syntax.scala
+++ b/fetch/src/main/scala/syntax.scala
@@ -44,4 +44,9 @@ object syntax {
 
     def batchAll: Fetch[F, List[A]] = Fetch.batchAll(fetches: _*)
   }
+
+  implicit class SeqSyntax[A](val as: Seq[A]) extends AnyVal {
+
+    def batchAllWith[F[_]: Monad, B](f: A => Fetch[F, B]) = Fetch.batchAll(as.map(f): _*)
+  }
 }

--- a/fetch/src/main/scala/syntax.scala
+++ b/fetch/src/main/scala/syntax.scala
@@ -18,6 +18,7 @@ package fetch
 
 import cats._
 import cats.effect._
+import fetch.Fetch
 
 object syntax {
 
@@ -37,5 +38,10 @@ object syntax {
 
     def fetch[F[_]: Concurrent]: Fetch[F, B] =
       Fetch.error[F, B](a)
+  }
+
+  implicit class FetchSeqBatchSyntax[F[_]: Monad, A](fetches: Seq[Fetch[F, A]]) {
+
+    def batchAll: Fetch[F, List[A]] = Fetch.batchAll(fetches: _*)
   }
 }

--- a/fetch/src/test/scala/FetchBatchingTests.scala
+++ b/fetch/src/test/scala/FetchBatchingTests.scala
@@ -152,7 +152,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large fetch to a datasource with a maximum batch size is split and executed in sequence" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List.range(1, 6).traverse(fetchBatchedDataSeq[F])
+      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataSeq[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -166,7 +166,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large fetch to a datasource with a maximum batch size is split and executed in parallel" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List.range(1, 6).traverse(fetchBatchedDataPar[F])
+      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataPar[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -180,8 +180,8 @@ class FetchBatchingTests extends FetchSpec {
 
   "Fetches to datasources with a maximum batch size should be split and executed in parallel and sequentially when using productR" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List.range(1, 6).traverse(fetchBatchedDataPar[F]) *>
-        List.range(1, 6).traverse(fetchBatchedDataSeq[F])
+      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataPar[F]): _*) *>
+        Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataSeq[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -195,8 +195,8 @@ class FetchBatchingTests extends FetchSpec {
 
   "Fetches to datasources with a maximum batch size should be split and executed in parallel and sequentially when using productL" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List.range(1, 6).traverse(fetchBatchedDataPar[F]) <*
-        List.range(1, 6).traverse(fetchBatchedDataSeq[F])
+      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataPar[F]): _*) <*
+        Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataSeq[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -210,7 +210,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large (many) fetch to a datasource with a maximum batch size is split and executed in sequence" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List(fetchBatchedDataSeq[F](1), fetchBatchedDataSeq[F](2), fetchBatchedDataSeq[F](3)).sequence
+      Fetch.batchAll(List(1, 2, 3).map(fetchBatchedDataSeq[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -224,7 +224,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large (many) fetch to a datasource with a maximum batch size is split and executed in parallel" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List(fetchBatchedDataPar[F](1), fetchBatchedDataPar[F](2), fetchBatchedDataPar[F](3)).sequence
+      Fetch.batchAll(List(1, 2, 3).map(fetchBatchedDataPar[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -247,7 +247,7 @@ class FetchBatchingTests extends FetchSpec {
     )
 
     val io = Fetch.runLog[IO](
-      ids.toList.traverse(fetchBatchedDataBigId[IO])
+      Fetch.batchAll(ids.toList.map(fetchBatchedDataBigId[IO]): _*)
     )
 
     io.map { case (log, result) =>

--- a/fetch/src/test/scala/FetchBatchingTests.scala
+++ b/fetch/src/test/scala/FetchBatchingTests.scala
@@ -22,6 +22,7 @@ import cats.instances.list._
 import cats.syntax.all._
 import cats.effect._
 import fetch._
+import fetch.syntax._
 
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -152,7 +153,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large fetch to a datasource with a maximum batch size is split and executed in sequence" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataSeq[F]): _*)
+      List.range(1, 6).map(fetchBatchedDataSeq[F]).batchAll
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -166,7 +167,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large fetch to a datasource with a maximum batch size is split and executed in parallel" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataPar[F]): _*)
+      List.range(1, 6).map(fetchBatchedDataPar[F]).batchAll
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -180,8 +181,8 @@ class FetchBatchingTests extends FetchSpec {
 
   "Fetches to datasources with a maximum batch size should be split and executed in parallel and sequentially when using productR" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataPar[F]): _*) *>
-        Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataSeq[F]): _*)
+      List.range(1, 6).map(fetchBatchedDataPar[F]).batchAll *>
+        List.range(1, 6).map(fetchBatchedDataSeq[F]).batchAll
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -195,8 +196,8 @@ class FetchBatchingTests extends FetchSpec {
 
   "Fetches to datasources with a maximum batch size should be split and executed in parallel and sequentially when using productL" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataPar[F]): _*) <*
-        Fetch.batchAll(List.range(1, 6).map(fetchBatchedDataSeq[F]): _*)
+      List.range(1, 6).map(fetchBatchedDataPar[F]).batchAll <*
+        List.range(1, 6).map(fetchBatchedDataSeq[F]).batchAll
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -210,7 +211,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large (many) fetch to a datasource with a maximum batch size is split and executed in sequence" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      Fetch.batchAll(List(1, 2, 3).map(fetchBatchedDataSeq[F]): _*)
+      List(1, 2, 3).map(fetchBatchedDataSeq[F]).batchAll
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -224,7 +225,7 @@ class FetchBatchingTests extends FetchSpec {
 
   "A large (many) fetch to a datasource with a maximum batch size is split and executed in parallel" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      Fetch.batchAll(List(1, 2, 3).map(fetchBatchedDataPar[F]): _*)
+      List(1, 2, 3).map(fetchBatchedDataPar[F]).batchAll
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -247,7 +248,7 @@ class FetchBatchingTests extends FetchSpec {
     )
 
     val io = Fetch.runLog[IO](
-      Fetch.batchAll(ids.toList.map(fetchBatchedDataBigId[IO]): _*)
+      ids.toList.map(fetchBatchedDataBigId[IO]).batchAll
     )
 
     io.map { case (log, result) =>

--- a/fetch/src/test/scala/FetchSyntaxTests.scala
+++ b/fetch/src/test/scala/FetchSyntaxTests.scala
@@ -20,6 +20,7 @@ import cats.syntax.all._
 import cats.effect._
 
 import fetch.syntax._
+import fetch.Fetch
 
 class FetchSyntaxTests extends FetchSpec {
   import TestHelper._
@@ -44,5 +45,16 @@ class FetchSyntaxTests extends FetchSpec {
     val e2 = io2.handleError(err => 42)
 
     (e1, e2).mapN(_ shouldEqual _).unsafeToFuture()
+  }
+
+  "`batchAll` syntax allows batching sequences of fetches and is equivalent to Fetch.batchAll" in {
+    def fetches[F[_]: Concurrent] = List(one(1), one(2), one(3))
+    val fetchWithSyntax           = fetches[IO].batchAll
+    val fetchManual               = Fetch.batchAll(fetches[IO]: _*)
+
+    val result1 = Fetch.runLog[IO](fetchWithSyntax)
+    val result2 = Fetch.runLog[IO](fetchManual)
+
+    result1 shouldEqual result2
   }
 }

--- a/fetch/src/test/scala/FetchTests.scala
+++ b/fetch/src/test/scala/FetchTests.scala
@@ -154,7 +154,7 @@ class FetchTests extends FetchSpec {
     }.unsafeToFuture()
   }
 
-  "Traversals are implicitly batched" in {
+  "Traversals are NOT implicitly batched" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
       for {
         manies <- many(3)
@@ -165,11 +165,11 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual List(0, 1, 2)
-      log.rounds.size shouldEqual 2
+      log.rounds.size shouldEqual 4
     }.unsafeToFuture()
   }
 
-  "Sequencing is implicitly batched" in {
+  "Sequencing is NOT implicitly batched" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
       List(one(1), one(2), one(3)).sequence
 
@@ -177,16 +177,16 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual List(1, 2, 3)
-      log.rounds.size shouldEqual 1
+      log.rounds.size shouldEqual 3
       totalFetched(log.rounds) shouldEqual 3
-      totalBatches(log.rounds) shouldEqual 1
+      totalBatches(log.rounds) shouldEqual 0
     }.unsafeToFuture()
   }
 
   "Identities are deduped when batched" in {
     val sources = List(1, 1, 2)
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      sources.traverse(one[F])
+      Fetch.batchAll(sources.map(one[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -315,25 +315,25 @@ class FetchTests extends FetchSpec {
     }.unsafeToFuture()
   }
 
-  "Every level of sequenced concurrent fetches is batched" in {
+  "Every level of batched, concurrent fetches is batched" in {
     def aFetch[F[_]: Concurrent] =
       for {
-        a <- List(2, 3, 4).traverse(one[F])   // round 1
-        b <- List(0, 1).traverse(many[F])     // round 2
-        c <- List(9, 10, 11).traverse(one[F]) // round 3
+        a <- Fetch.batchAll(List(2, 3, 4).map(one[F]): _*)   // round 1
+        b <- Fetch.batchAll(List(0, 1).map(many[F]): _*)     // round 2
+        c <- Fetch.batchAll(List(9, 10, 11).map(one[F]): _*) // round 3
       } yield c
 
     def anotherFetch[F[_]: Concurrent] =
       for {
-        a <- List(5, 6, 7).traverse(one[F])    // round 1
-        b <- List(2, 3).traverse(many[F])      // round 2
-        c <- List(12, 13, 14).traverse(one[F]) // round 3
+        a <- Fetch.batchAll(List(5, 6, 7).map(one[F]): _*)    // round 1
+        b <- Fetch.batchAll(List(2, 3).map(many[F]): _*)      // round 2
+        c <- Fetch.batchAll(List(12, 13, 14).map(one[F]): _*) // round 3
       } yield c
 
     def fetch[F[_]: Concurrent] =
       (
         (aFetch[F], anotherFetch[F]).tupled,
-        List(15, 16, 17).traverse(one[F]) // round 1
+        Fetch.batchAll(List(15, 16, 17).map(one[F]): _*) // round 1
       ).tupled
 
     val io = Fetch.runLog[IO](fetch)
@@ -359,9 +359,22 @@ class FetchTests extends FetchSpec {
     }.unsafeToFuture()
   }
 
-  "Sequenced fetches are run concurrently" in {
+  "Sequenced fetches are NOT run concurrently" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
       List(one(1), one(2), one(3), anotherOne(4), anotherOne(5)).sequence
+
+    val io = Fetch.runLog[IO](fetch)
+
+    io.map { case (log, result) =>
+      result shouldEqual List(1, 2, 3, 4, 5)
+      log.rounds.size shouldEqual 5
+      totalBatches(log.rounds) shouldEqual 0
+    }.unsafeToFuture()
+  }
+
+  "Manually batched fetches are run concurrently" in {
+    def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
+      Fetch.batchAll((List(1, 2, 3).map(one(_)) ++ List(4, 5).map(anotherOne(_))): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -372,7 +385,7 @@ class FetchTests extends FetchSpec {
     }.unsafeToFuture()
   }
 
-  "Sequenced fetches are deduped" in {
+  "Sequenced fetches are NOT deduped" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
       List(one(1), one(2), one(1)).sequence
 
@@ -380,13 +393,27 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual List(1, 2, 1)
+      log.rounds.size shouldEqual 2
+      totalBatches(log.rounds) shouldEqual 0
+      totalFetched(log.rounds) shouldEqual 2
+    }.unsafeToFuture()
+  }
+
+  "Manually batched fetches are deduped" in {
+    def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
+      Fetch.batchAll(List(1, 2, 1).map(one(_)): _*)
+
+    val io = Fetch.runLog[IO](fetch)
+
+    io.map { case (log, result) =>
+      result shouldEqual List(1, 2, 1)
       log.rounds.size shouldEqual 1
       totalBatches(log.rounds) shouldEqual 1
       totalFetched(log.rounds) shouldEqual 2
     }.unsafeToFuture()
   }
 
-  "Traversals are batched" in {
+  "Traversals are NOT batched" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
       List(1, 2, 3).traverse(one[F])
 
@@ -394,14 +421,14 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual List(1, 2, 3)
-      log.rounds.size shouldEqual 1
-      totalBatches(log.rounds) shouldEqual 1
+      log.rounds.size shouldEqual 3
+      totalBatches(log.rounds) shouldEqual 0
     }.unsafeToFuture()
   }
 
   "Duplicated sources are only fetched once" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List(1, 2, 1).traverse(one[F])
+      Fetch.batchAll(List(1, 2, 1).map(one[F]): _*)
 
     val io = Fetch.runLog[IO](fetch)
 
@@ -412,11 +439,27 @@ class FetchTests extends FetchSpec {
     }.unsafeToFuture()
   }
 
-  "Sources that can be fetched concurrently inside a for comprehension will be" in {
+  "Sources that can be fetched concurrently inside a for comprehension will NOT automatically be concurrent" in {
     def fetch[F[_]: Concurrent] =
       for {
         v      <- Fetch.pure[F, List[Int]](List(1, 2, 1))
         result <- v.traverse(one[F])
+      } yield result
+
+    val io = Fetch.runLog[IO](fetch)
+
+    io.map { case (log, result) =>
+      result shouldEqual List(1, 2, 1)
+      log.rounds.size shouldEqual 2
+      totalFetched(log.rounds) shouldEqual 2
+    }.unsafeToFuture()
+  }
+
+  "Sources that are manually batched will be fetched concurrently" in {
+    def fetch[F[_]: Concurrent] =
+      for {
+        v      <- Fetch.pure[F, List[Int]](List(1, 2, 1))
+        result <- Fetch.batchAll(v.map(one[F]): _*)
       } yield result
 
     val io = Fetch.runLog[IO](fetch)
@@ -473,7 +516,7 @@ class FetchTests extends FetchSpec {
   "Batched elements are cached and thus not fetched more than once" in {
     def fetch[F[_]: Concurrent] =
       for {
-        _          <- List(1, 2, 3).traverse(one[F])
+        _          <- Fetch.batchAll(List(1, 2, 3).map(one[F]): _*)
         aOne       <- one(1)
         anotherOne <- one(1)
         _          <- one(1)
@@ -631,7 +674,7 @@ class FetchTests extends FetchSpec {
         anotherOne <- one(1)
         _          <- one(1)
         _          <- one(2)
-        _          <- List(1, 2, 3).traverse(one[F])
+        _          <- Fetch.batchAll(List(1, 2, 3).map(one[F]): _*)
         _          <- one(3)
         _          <- one(1)
         _          <- one(1)
@@ -787,17 +830,17 @@ class FetchTests extends FetchSpec {
     Fetch.run[IO](fetch).map(_ shouldEqual Some(1)).unsafeToFuture()
   }
 
-  "We can run optional fetches with traverse" in {
+  "We can run optional fetches with Fetch.batchAll" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] =
-      List(1, 2, 3).traverse(maybeOpt[F]).map(_.flatten)
+      Fetch.batchAll(List(1, 2, 3).map(maybeOpt[F]): _*).map(_.flatten)
 
     Fetch.run[IO](fetch).map(_ shouldEqual List(1, 3)).unsafeToFuture()
   }
 
   "We can run optional fetches with other data sources" in {
     def fetch[F[_]: Concurrent]: Fetch[F, List[Int]] = {
-      val ones   = List(1, 2, 3).traverse(one[F])
-      val maybes = List(1, 2, 3).traverse(maybeOpt[F])
+      val ones   = Fetch.batchAll(List(1, 2, 3).map(one[F]): _*)
+      val maybes = Fetch.batchAll(List(1, 2, 3).map(maybeOpt[F]): _*)
       (ones, maybes).mapN { case (os, ms) => os ++ ms.flatten }
     }
 

--- a/microsite/docs/docs.md
+++ b/microsite/docs/docs.md
@@ -232,7 +232,7 @@ object OnlyBatched extends Data[Int, Int]{
 
 ## Creating a runtime
 
-Since we'lll use `IO` from the `cats-effect` library to execute our fetches, we'll need a runtime for executing our `IO` instances. This includes a `ContextShift[IO]` used for running the `IO` instances and a `Timer[IO]` that is used for scheduling, let's go ahead and create them, we'll use a `java.util.concurrent.ScheduledThreadPoolExecutor` with a few threads to run our fetches.
+Since we'll use `IO` from the `cats-effect` library to execute our fetches, we'll need a runtime for executing our `IO` instances. This includes a `ContextShift[IO]` used for running the `IO` instances and a `Timer[IO]` that is used for scheduling, let's go ahead and create them, we'll use a `java.util.concurrent.ScheduledThreadPoolExecutor` with a few threads to run our fetches.
 
 ```scala mdoc:silent
 import cats.effect._

--- a/microsite/docs/docs.md
+++ b/microsite/docs/docs.md
@@ -235,19 +235,14 @@ object OnlyBatched extends Data[Int, Int]{
 
 ## Creating a runtime
 
-Since we'll use `IO` from the `cats-effect` library to execute our fetches, we'll need a runtime for executing our `IO` instances. This includes a `ContextShift[IO]` used for running the `IO` instances and a `Timer[IO]` that is used for scheduling, let's go ahead and create them, we'll use a `java.util.concurrent.ScheduledThreadPoolExecutor` with a few threads to run our fetches.
+Since we'll use `IO` from the `cats-effect` library to execute our fetches, we'll need an `IORuntime` for executing our `IO` instances.
 
 ```scala mdoc:silent
-import cats.effect._
-import java.util.concurrent._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-
-val executor = new ScheduledThreadPoolExecutor(4)
-val executionContext: ExecutionContext = ExecutionContext.fromExecutor(executor)
-
-import cats.effect.unsafe.implicits.global
+import cats.effect.unsafe.implicits.global //Give
 ```
+
+Normally, in your applications, this is provided by `IOApp`, and you should not need to import this except in limited scenarios such as test environments that do not have Cats Effect integration.
+For more information, and particularly on why you would usually not want to make one of these yourself, [see this post by Daniel Spiewak](https://github.com/typelevel/cats-effect/discussions/1562#discussioncomment-254838)
 
 ## Creating and running a fetch
 
@@ -925,10 +920,6 @@ Let's break down the output from `describe`:
  - The nested lines represent the different rounds of execution
   + "Fetch one" rounds are executed for getting an identity from one data source
   + "Batch" rounds are executed for getting a batch of identities from one data source
-
-```scala mdoc:invisible
-executor.shutdownNow()
-```
 
 # Resources
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -15,7 +15,7 @@ object ProjectPlugin extends AutoPlugin {
       Seq(
         libraryDependencies ++=
           Seq(
-            "org.typelevel" %%% "cats-effect" % "3.2.9",
+            "org.typelevel" %%% "cats-effect" % "3.3.4",
             "org.scalatest" %%% "scalatest"   % "3.2.10" % "test"
           )
       )


### PR DESCRIPTION
Fixes #585 

This adds a new function to the `Fetch` companion object called `batchAll`. It takes a varargs of `Fetch[F, A]` and returns a `Fetch[F, List[A]]` back, with the assumption that all of the fetches provided are to be batched or run concurrently. This is to replace the previous behavior of automatically batching fetches that are included in `traverse` calls, because that functionality depended on implementation details of the Cats traverse instances, which have changed as of Cats 2.7.0.

Each of the tests that failed have been updated to now use `Fetch.batchAll` and test cases that specified the auto-batching behavior of `traverse` have been altered, and duplicated with changes, to demonstrate that this behavior no longer occurs.

Marked as WIP because I still have to finish the documentation but the code is ready for review.