### PR TITLE
Logging cached requests

### DIFF
--- a/fetch-debug/src/main/scala/debug.scala
+++ b/fetch-debug/src/main/scala/debug.scala
@@ -90,10 +90,10 @@ object debug {
 
   def showRequest(r: Request): Document =
     r.request match {
-      case FetchOne(id, d) =>
-        Document.text(s"[Fetch one] From `${d.name}` with id $id") :-: showDuration(r.duration)
-      case Batch(ids, d) =>
-        Document.text(s"[Batch] From `${d.name}` with ids ${ids.toList}") :-: showDuration(
+      case FetchOne(id, d, cached) =>
+        Document.text(s"[Fetch one] From `${d.name}` with id $id cached $cached") :-: showDuration(r.duration)
+      case Batch(ids, d, cached) =>
+        Document.text(s"[Batch] From `${d.name}` with ids ${ids.toList} cached $cached") :-: showDuration(
           r.duration
         )
     }

--- a/fetch-debug/src/main/scala/debug.scala
+++ b/fetch-debug/src/main/scala/debug.scala
@@ -91,11 +91,11 @@ object debug {
   def showRequest(r: Request): Document =
     r.request match {
       case FetchOne(id, d, cached) =>
-        Document.text(s"[Fetch one] From `${d.name}` with id $id cached $cached") :-: showDuration(r.duration)
+        Document.text(s"[Fetch one] From `${d.name}` with id $id cached $cached") :-:
+          showDuration(r.duration)
       case Batch(ids, d, cached) =>
-        Document.text(s"[Batch] From `${d.name}` with ids ${ids.toList} cached $cached") :-: showDuration(
-          r.duration
-        )
+        Document.text(s"[Batch] From `${d.name}` with ids ${ids.toList} cached $cached") :-:
+          showDuration(r.duration)
     }
 
   def showMissing(d: Data[_, _], ids: List[_]): Document =

--- a/fetch-examples/src/test/scala/GraphQLExample.scala
+++ b/fetch-examples/src/test/scala/GraphQLExample.scala
@@ -38,8 +38,10 @@ class GraphQLExample extends AnyWordSpec with Matchers {
 
   def countFetches(r: Request): Int =
     r.request match {
-      case FetchOne(_, _) => 1
-      case Batch(ids, _)  => ids.toList.size
+      case FetchOne(_, _, false) => 1
+      case Batch(ids, _, false)  => ids.toList.size
+      case FetchOne(_, _, true)  => 0
+      case Batch(_, _, true)     => 0
     }
 
   def totalFetched(rs: Seq[Round]): Int =
@@ -47,8 +49,10 @@ class GraphQLExample extends AnyWordSpec with Matchers {
 
   def countBatches(r: Request): Int =
     r.request match {
-      case FetchOne(_, _) => 0
-      case Batch(_, _)    => 1
+      case FetchOne(_, _, false) => 0
+      case Batch(_, _, false)    => 1
+      case FetchOne(_, _, true)  => 0
+      case Batch(_, _, true)     => 0
     }
 
   def totalBatches(rs: Seq[Round]): Int =

--- a/fetch/src/main/scala/fetch.scala
+++ b/fetch/src/main/scala/fetch.scala
@@ -33,11 +33,18 @@ object `package` {
     def data: Data[I, A]
     def identities: Set[I]
   }
-  private[fetch] final case class FetchOne[I, A](id: I, data: Data[I, A], cached: Boolean = false) extends FetchQuery[I, A] {
+  private[fetch] final case class FetchOne[I, A](
+      id: I,
+      data: Data[I, A],
+      cached: Boolean = false
+  ) extends FetchQuery[I, A] {
     override def identities: Set[I] = Set(id)
   }
-  private[fetch] final case class Batch[I, A](ids: NonEmptyList[I], data: Data[I, A], cached: Boolean = false)
-      extends FetchQuery[I, A] {
+  private[fetch] final case class Batch[I, A](
+      ids: NonEmptyList[I],
+      data: Data[I, A],
+      cached: Boolean = false
+  ) extends FetchQuery[I, A] {
     override def identities: Set[I] = ids.toList.toSet
   }
 
@@ -663,15 +670,16 @@ object `package` {
       maybeCached <- c.lookup(q.id, q.data)
       result <- maybeCached match {
         // Cached
-        case Some(v) => runCombinationResult(putResult, FetchDone(v)).as(
-          List(Request(FetchOne(q.id, q.data, cached = true), startTime, startTime))
-        )
+        case Some(v) =>
+          runCombinationResult(putResult, FetchDone(v)).as(
+            List(Request(FetchOne(q.id, q.data, cached = true), startTime, startTime))
+          )
 
         // Not cached, must fetch
         case None =>
           for {
-            o         <- ds.fetch(q.id)
-            endTime   <- T.monotonic.map(_.toMillis)
+            o       <- ds.fetch(q.id)
+            endTime <- T.monotonic.map(_.toMillis)
             result <- o match {
               // Fetched
               case Some(a) =>
@@ -715,8 +723,8 @@ object `package` {
       }
       cachedResults = cached.toMap
       startTime <- T.monotonic.map(_.toMillis)
-      cachedRequests = cached.toNel.map(
-        x => Request(Batch(x.map(_._1), q.data, cached = true), startTime, startTime)
+      cachedRequests = cached.toNel.map(x =>
+        Request(Batch(x.map(_._1), q.data, cached = true), startTime, startTime)
       )
       result <- uncachedIds.toNel match {
         // All cached

--- a/fetch/src/test/scala/FetchReportingTests.scala
+++ b/fetch/src/test/scala/FetchReportingTests.scala
@@ -144,7 +144,7 @@ class FetchReportingTests extends FetchSpec {
     val io = Fetch.runLog[IO](fetch)
 
     io.map { case (log, result) =>
-      log.rounds.size shouldEqual 2
+      log.rounds.size shouldEqual 3
       totalBatches(log.rounds) shouldEqual 1
       totalFetched(log.rounds) shouldEqual 3 + 1
     }.unsafeToFuture()

--- a/fetch/src/test/scala/FetchSpec.scala
+++ b/fetch/src/test/scala/FetchSpec.scala
@@ -30,8 +30,10 @@ class FetchSpec extends AsyncFreeSpec with Matchers {
 
   def countFetches(r: Request): Int =
     r.request match {
-      case FetchOne(_, _) => 1
-      case Batch(ids, _)  => ids.toList.size
+      case FetchOne(_, _, false) => 1
+      case Batch(ids, _, false)  => ids.toList.size
+      case FetchOne(_, _, true)  => 0
+      case Batch(_, _, true)     => 0
     }
 
   def totalFetched(rs: Seq[Round]): Int =
@@ -39,8 +41,10 @@ class FetchSpec extends AsyncFreeSpec with Matchers {
 
   def countBatches(r: Request): Int =
     r.request match {
-      case FetchOne(_, _) => 0
-      case Batch(_, _)    => 1
+      case FetchOne(_, _, false) => 0
+      case Batch(_, _, false)    => 1
+      case FetchOne(_, _, true)  => 0
+      case Batch(_, _, true)     => 0
     }
 
   def totalBatches(rs: Seq[Round]): Int =

--- a/fetch/src/test/scala/FetchTests.scala
+++ b/fetch/src/test/scala/FetchTests.scala
@@ -16,15 +16,10 @@
 
 package fetch
 
-import scala.concurrent._
-import java.util.concurrent._
-import scala.concurrent.duration._
-
 import cats._
+import cats.data.NonEmptyList
 import cats.effect._
 import cats.instances.list._
-import cats.instances.option._
-import cats.data.NonEmptyList
 import cats.syntax.all._
 import fetch.syntax._
 
@@ -284,8 +279,8 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual ((1, 2), 3)
-      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 1  // cached rounds
-      log.rounds.size shouldEqual 3                                       // all rounds
+      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 1 // cached rounds
+      log.rounds.size shouldEqual 3                                      // all rounds
       totalBatches(log.rounds) shouldEqual 2
       totalFetched(log.rounds) shouldEqual 5
     }.unsafeToFuture()
@@ -311,8 +306,8 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual (1, 2)
-      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 1  // cached rounds
-      log.rounds.size shouldEqual 3                                       // all rounds
+      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 1 // cached rounds
+      log.rounds.size shouldEqual 3                                      // all rounds
       totalBatches(log.rounds) shouldEqual 2
       totalFetched(log.rounds) shouldEqual 4
     }.unsafeToFuture()
@@ -532,8 +527,8 @@ class FetchTests extends FetchSpec {
     val io = Fetch.runLog[IO](fetch)
 
     io.map { case (log, result) =>
-      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 7  // cached rounds
-      log.rounds.size shouldEqual 8                                       // all rounds
+      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 7 // cached rounds
+      log.rounds.size shouldEqual 8                                      // all rounds
       totalFetched(log.rounds) shouldEqual 3
     }.unsafeToFuture()
   }

--- a/fetch/src/test/scala/FetchTests.scala
+++ b/fetch/src/test/scala/FetchTests.scala
@@ -196,7 +196,7 @@ class FetchTests extends FetchSpec {
       log.rounds.size shouldEqual 1
       log.rounds.head.queries.size shouldEqual 1
       log.rounds.head.queries.head.request should matchPattern {
-        case Batch(NonEmptyList(1, List(2)), _) =>
+        case Batch(NonEmptyList(1, List(2)), _, _) =>
       }
     }.unsafeToFuture()
   }
@@ -284,7 +284,8 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual ((1, 2), 3)
-      log.rounds.size shouldEqual 2
+      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 1  // cached rounds
+      log.rounds.size shouldEqual 3                                       // all rounds
       totalBatches(log.rounds) shouldEqual 2
       totalFetched(log.rounds) shouldEqual 5
     }.unsafeToFuture()
@@ -310,7 +311,8 @@ class FetchTests extends FetchSpec {
 
     io.map { case (log, result) =>
       result shouldEqual (1, 2)
-      log.rounds.size shouldEqual 2
+      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 1  // cached rounds
+      log.rounds.size shouldEqual 3                                       // all rounds
       totalBatches(log.rounds) shouldEqual 2
       totalFetched(log.rounds) shouldEqual 4
     }.unsafeToFuture()
@@ -530,8 +532,8 @@ class FetchTests extends FetchSpec {
     val io = Fetch.runLog[IO](fetch)
 
     io.map { case (log, result) =>
-      result shouldEqual 2
-      log.rounds.size shouldEqual 1
+      log.rounds.count(_.queries.forall(_.request.cached)) shouldEqual 7  // cached rounds
+      log.rounds.size shouldEqual 8                                       // all rounds
       totalFetched(log.rounds) shouldEqual 3
     }.unsafeToFuture()
   }
@@ -561,7 +563,7 @@ class FetchTests extends FetchSpec {
     io.map { case (log, result) =>
       result shouldEqual 2
       totalFetched(log.rounds) shouldEqual 0
-      log.rounds.size shouldEqual 0
+      log.rounds.size shouldEqual 8
     }.unsafeToFuture()
   }
 


### PR DESCRIPTION
We suggest logging cached requests. These logs allow us to invalidate the cache more granularly. Additionally, it is helpful to see which requests have been cached in the logs.

```
Fetch execution 🕛 0,08 seconds

  [Round 1] 🕛 0,02 seconds
    [Batch] From `Users` with ids List(1, 2) cached false 🕛 0,02 seconds
  [Round 2] 🕛 0,00 seconds
    [Fetch one] From `Users` with id 2 cached true 🕛 0,00 seconds
  [Round 3] 🕛 0,01 seconds
    [Fetch one] From `Users` with id 4 cached false 🕛 0,01 seconds
  [Round 4] 🕛 0,01 seconds
    [Batch] From `Posts` with ids List(1, 2, 3) cached false 🕛 0,01 seconds
    [Batch] From `Users` with ids List(3) cached false 🕛 0,01 seconds
    [Batch] From `Users` with ids List(1, 2) cached true 🕛 0,00 seconds
```